### PR TITLE
Prevents platform callback from being called multiple times

### DIFF
--- a/lib/platform.js
+++ b/lib/platform.js
@@ -27,8 +27,10 @@ MisfitBoltPlatform.prototype.accessories = function(callback) {
     });
     var accessory = new MisfitBoltAccessory(bolt, config, that.log);
     accessories.push(accessory);
+
+    var totalAccessories = accessories.length;
     accessory.initialize(function() {
-      if (accessories.length == configs.length) {
+      if (totalAccessories == configs.length) {
         callback(accessories);
       }
     });


### PR DESCRIPTION
Sometimes when there are multiple Bolts, the initialization would trigger
the callback at the same time causing homebridge to spit back an error.
This captures the accessories length in the callback closure to prevent the value
from changing.
